### PR TITLE
URL Cleanup

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -64,7 +64,7 @@
                 }
             ],
             "description": "Common String Manipulations with regard to casing and singular/plural rules.",
-            "homepage": "http://www.doctrine-project.org",
+            "homepage": "https://www.doctrine-project.org",
             "keywords": [
                 "inflection",
                 "pluralize",
@@ -1381,11 +1381,11 @@
                 {
                     "name": "Jordi Boggiano",
                     "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
+                    "homepage": "https://seld.be"
                 }
             ],
             "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
-            "homepage": "http://github.com/Seldaek/monolog",
+            "homepage": "https://github.com/Seldaek/monolog",
             "keywords": [
                 "log",
                 "logging",
@@ -1440,7 +1440,7 @@
                 }
             ],
             "description": "A simple API extension for DateTime.",
-            "homepage": "http://carbon.nesbot.com",
+            "homepage": "https://carbon.nesbot.com",
             "keywords": [
                 "date",
                 "datetime",
@@ -1529,7 +1529,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common Container Interface (PHP FIG PSR-11)",
@@ -1578,7 +1578,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for logging libraries",
@@ -1625,7 +1625,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interfaces for simple caching",
@@ -2286,7 +2286,7 @@
                 {
                     "name": "Vance Lucas",
                     "email": "vance@vancelucas.com",
-                    "homepage": "http://www.vancelucas.com"
+                    "homepage": "http://vancelucas.com"
                 }
             ],
             "description": "Loads environment variables from `.env` to `getenv()`, `$_ENV` and `$_SERVER` automagically.",
@@ -2342,7 +2342,7 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
+                    "homepage": "https://ocramius.github.com/"
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
@@ -2493,12 +2493,12 @@
                 {
                     "name": "Pádraic Brady",
                     "email": "padraic.brady@gmail.com",
-                    "homepage": "http://blog.astrumfutura.com"
+                    "homepage": "https://blog.astrumfutura.com"
                 },
                 {
                     "name": "Dave Marshall",
                     "email": "dave.marshall@atstsolutions.co.uk",
-                    "homepage": "http://davedevelopment.co.uk"
+                    "homepage": "https://davedevelopment.co.uk"
                 }
             ],
             "description": "Mockery is a simple yet flexible PHP mock object framework",
@@ -2711,7 +2711,7 @@
                 }
             ],
             "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
+            "homepage": "https://www.phpdoc.org",
             "keywords": [
                 "FQSEN",
                 "phpDocumentor",
@@ -3422,7 +3422,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://www.github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -3490,7 +3490,7 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
@@ -3542,7 +3542,7 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
@@ -3690,7 +3690,7 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "homepage": "https://www.github.com/sebastianbergmann/recursion-context",
             "time": "2017-03-03T06:23:57+00:00"
         },
         {

--- a/readme.md
+++ b/readme.md
@@ -22,4 +22,4 @@ If you use other names, you must map them so that they fit predefined ones.
 
 ## License
 
-The [Lumen Framework](https://lumen.laravel.com) is open-sourced software licensed under the [MIT license](http://opensource.org/licenses/MIT)
+The [Lumen Framework](https://lumen.laravel.com) is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://everzet.com (200) with 1 occurrences could not be migrated:  
   ([https](https://everzet.com) result SSLHandshakeException).
* [ ] http://nesbot.com (200) with 1 occurrences could not be migrated:  
   ([https](https://nesbot.com) result SSLHandshakeException).
* [ ] http://www.vancelucas.com (302) with 1 occurrences could not be migrated:  
   ([https](https://www.vancelucas.com) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://blog.astrumfutura.com (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://blog.astrumfutura.com ([https](https://blog.astrumfutura.com) result ConnectTimeoutException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://carbon.nesbot.com with 1 occurrences migrated to:  
  https://carbon.nesbot.com ([https](https://carbon.nesbot.com) result 200).
* [ ] http://davedevelopment.co.uk with 1 occurrences migrated to:  
  https://davedevelopment.co.uk ([https](https://davedevelopment.co.uk) result 200).
* [ ] http://github.com/Seldaek/monolog with 1 occurrences migrated to:  
  https://github.com/Seldaek/monolog ([https](https://github.com/Seldaek/monolog) result 200).
* [ ] http://opensource.org/licenses/MIT with 1 occurrences migrated to:  
  https://opensource.org/licenses/MIT ([https](https://opensource.org/licenses/MIT) result 200).
* [ ] http://seld.be with 1 occurrences migrated to:  
  https://seld.be ([https](https://seld.be) result 200).
* [ ] http://www.doctrine-project.org with 1 occurrences migrated to:  
  https://www.doctrine-project.org ([https](https://www.doctrine-project.org) result 200).
* [ ] http://www.php-fig.org/ with 3 occurrences migrated to:  
  https://www.php-fig.org/ ([https](https://www.php-fig.org/) result 200).
* [ ] http://www.phpdoc.org with 1 occurrences migrated to:  
  https://www.phpdoc.org ([https](https://www.phpdoc.org) result 200).
* [ ] http://ocramius.github.com/ with 1 occurrences migrated to:  
  https://ocramius.github.com/ ([https](https://ocramius.github.com/) result 301).
* [ ] http://www.github.com/sebastianbergmann/environment with 1 occurrences migrated to:  
  https://www.github.com/sebastianbergmann/environment ([https](https://www.github.com/sebastianbergmann/environment) result 301).
* [ ] http://www.github.com/sebastianbergmann/exporter with 1 occurrences migrated to:  
  https://www.github.com/sebastianbergmann/exporter ([https](https://www.github.com/sebastianbergmann/exporter) result 301).
* [ ] http://www.github.com/sebastianbergmann/global-state with 1 occurrences migrated to:  
  https://www.github.com/sebastianbergmann/global-state ([https](https://www.github.com/sebastianbergmann/global-state) result 301).
* [ ] http://www.github.com/sebastianbergmann/recursion-context with 1 occurrences migrated to:  
  https://www.github.com/sebastianbergmann/recursion-context ([https](https://www.github.com/sebastianbergmann/recursion-context) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 1 occurrences